### PR TITLE
* Fix NDC to screen coordinate mapping

### DIFF
--- a/EnginePlugins/AssetIO/ModelImporter_PLY.cpp
+++ b/EnginePlugins/AssetIO/ModelImporter_PLY.cpp
@@ -8,7 +8,7 @@
 #include "Utils/Helpers.h"
 
 using namespace vz;
-bool ImportModel_PLY(const std::string &fileName, vz::GeometryComponent *geometry)
+bool ImportModel_PLY(const std::string& fileName, vz::GeometryComponent* geometry)
 {
 	std::ifstream file(fileName, std::ios::binary);
 	if (!file.is_open())
@@ -51,15 +51,15 @@ bool ImportModel_PLY(const std::string &fileName, vz::GeometryComponent *geometr
 	std::vector<Primitive> parts(1);
 	geometry->CopyPrimitivesFrom(parts);
 
-	Primitive *mutable_primitive = geometry->GetMutablePrimitive(0);
+	Primitive* mutable_primitive = geometry->GetMutablePrimitive(0);
 
-	std::vector<XMFLOAT3> *vertex_positions = &mutable_primitive->GetMutableVtxPositions();
-	std::vector<XMFLOAT3> *vertex_normals = &mutable_primitive->GetMutableVtxNormals();
-	std::vector<SH> *vertex_SHs = &mutable_primitive->GetMutableVtxSHs();
-	std::vector<XMFLOAT4> *vertex_SOs = &mutable_primitive->GetMutableVtxScaleOpacities();
-	std::vector<XMFLOAT4> *vertex_Qts = &mutable_primitive->GetMutableVtxQuaternions();
+	std::vector<XMFLOAT3>* vertex_positions = &mutable_primitive->GetMutableVtxPositions();
+	std::vector<XMFLOAT3>* vertex_normals = &mutable_primitive->GetMutableVtxNormals();
+	std::vector<SH>* vertex_SHs = &mutable_primitive->GetMutableVtxSHs();
+	std::vector<XMFLOAT4>* vertex_SOs = &mutable_primitive->GetMutableVtxScaleOpacities();
+	std::vector<XMFLOAT4>* vertex_Qts = &mutable_primitive->GetMutableVtxQuaternions();
 
-	std::vector<uint32_t> *indices = &mutable_primitive->GetMutableIdxPrimives();
+	std::vector<uint32_t>* indices = &mutable_primitive->GetMutableIdxPrimives();
 
 	vertex_positions->reserve(vertexCount);
 	vertex_normals->reserve(vertexCount);
@@ -76,26 +76,26 @@ bool ImportModel_PLY(const std::string &fileName, vz::GeometryComponent *geometr
 		float sh_coeffs[48]; // 48 floats for SH coefficients (16 XMFLOAT3 = 48 floats)
 
 		// Read vertex position and normal
-		file.read(reinterpret_cast<char *>(&x), sizeof(float));
-		file.read(reinterpret_cast<char *>(&y), sizeof(float));
-		file.read(reinterpret_cast<char *>(&z), sizeof(float));
+		file.read(reinterpret_cast<char*>(&x), sizeof(float));
+		file.read(reinterpret_cast<char*>(&y), sizeof(float));
+		file.read(reinterpret_cast<char*>(&z), sizeof(float));
 
-		file.read(reinterpret_cast<char *>(&nx), sizeof(float));
-		file.read(reinterpret_cast<char *>(&ny), sizeof(float));
-		file.read(reinterpret_cast<char *>(&nz), sizeof(float));
+		file.read(reinterpret_cast<char*>(&nx), sizeof(float));
+		file.read(reinterpret_cast<char*>(&ny), sizeof(float));
+		file.read(reinterpret_cast<char*>(&nz), sizeof(float));
 
 		indices->push_back(i);
 
 		// Read 48 SH coefficients
 		for (int j = 0; j < 48; j++)
 		{
-			file.read(reinterpret_cast<char *>(&sh_coeffs[j]), sizeof(float));
+			file.read(reinterpret_cast<char*>(&sh_coeffs[j]), sizeof(float));
 		}
 
 		// Read opacity, scale, rotation
-		file.read(reinterpret_cast<char *>(&opacity), sizeof(float));
-		file.read(reinterpret_cast<char *>(scale), sizeof(float) * 3);
-		file.read(reinterpret_cast<char *>(rot), sizeof(float) * 4);
+		file.read(reinterpret_cast<char*>(&opacity), sizeof(float));
+		file.read(reinterpret_cast<char*>(scale), sizeof(float) * 3);
+		file.read(reinterpret_cast<char*>(rot), sizeof(float) * 4);
 
 		// 4. Store data
 		vertex_positions->emplace_back(x, y, z);

--- a/EnginePlugins/RendererDX12/Shaders/CS/testCS.hlsl
+++ b/EnginePlugins/RendererDX12/Shaders/CS/testCS.hlsl
@@ -1,3 +1,6 @@
+// HLSL Shader for Gaussian Screen-Space Covariance and Radius Computation
+// Includes: Covariance Matrix Inversion (EWA Algorithm), Eigenvalues, and Bounding Rectangle Calculation
+
 #include "../Globals.hlsli"
 #include "../ShaderInterop_GS.h"
 #include "../CommonHF/surfaceHF.hlsli"
@@ -8,38 +11,25 @@ PUSHCONSTANT(gaussians, GaussianPushConstants);
 RWTexture2D<unorm float4> inout_color : register(u0);
 RWStructuredBuffer<uint> touchedTiles_0 : register(u1);
 
-[numthreads(256, 1, 1)]
-void main(uint2 Gid : SV_GroupID, uint2 DTid : SV_DispatchThreadID, uint groupIndex : SV_GroupIndex)
+// Function: Get screen-space bounding rectangle for Gaussian
+void getRect(float2 p, int max_radius, uint2 grid, out uint2 rect_min, out uint2 rect_max)
 {
-    // Global thread index along X-axis
-    uint idx = DTid.x;
+    // Define block dimensions (BLOCK_X and BLOCK_Y need to match grid setup)
+    const int BLOCK_X = 16; // Tile width
+    const int BLOCK_Y = 16; // Tile height
 
-    // Exit if out of range
-    if (idx >= gaussians.num_gaussians)
-        return;
+    // Calculate rect_min
+    rect_min.x = min(grid.x, max(0, (int)((p.x - max_radius) / BLOCK_X)));
+    rect_min.y = min(grid.y, max(0, (int)((p.y - max_radius) / BLOCK_Y)));
 
-    // Atomically add 1 and retrieve the previous value
-    uint oldValue;
-    InterlockedAdd(touchedTiles_0[idx], 1, oldValue);
+    // Calculate rect_max
+    rect_max.x = min(grid.x, max(0, (int)((p.x + max_radius + BLOCK_X - 1) / BLOCK_X)));
+    rect_max.y = min(grid.y, max(0, (int)((p.y + max_radius + BLOCK_Y - 1) / BLOCK_Y)));
+}
 
-    // Read the updated value
-    uint newValue = touchedTiles_0[idx];
-
-    // Load camera data
-    ShaderCamera camera = GetCamera();
-    uint W = camera.internal_resolution.x;
-    uint H = camera.internal_resolution.y;
-
-    // Load instance and geometry
-    ShaderMeshInstance gs_instance = load_instance(gaussians.instanceIndex);
-    uint subsetIndex = gaussians.geometryIndex - gs_instance.geometryOffset;
-    ShaderGeometry geometry = load_geometry(subsetIndex);
-
-    // Fetch position
-    Buffer<float4> vb_pos_w = bindless_buffers_float4[geometry.vb_pos_w];
-    float3 pos = vb_pos_w[idx].xyz;
-
-    // Transform to clip space
+// Function: Convert world position to pixel coordinates
+int2 worldToPixel(float3 pos, ShaderCamera camera, uint W, uint H)
+{
     float4 p_view = mul(float4(pos, 1.0f), camera.view);
     float4 p_hom = mul(p_view, camera.projection);
 
@@ -50,25 +40,164 @@ void main(uint2 Gid : SV_GroupID, uint2 DTid : SV_DispatchThreadID, uint groupIn
     float3 p_proj = float3(p_hom.x * p_w, p_hom.y * p_w, p_hom.z * p_w);
 
     // Convert NDC (-1~1) to screen coordinates (0~W, 0~H)
-    float2 point_image = float2(
+    float2 screen_coords = float2(
         (p_proj.x * 0.5f + 0.5f) * (float)W,
         (p_proj.y * 0.5f + 0.5f) * (float)H
     );
 
-    // Round to nearest pixel
-    int2 point_pixel = int2(point_image + 0.5f);
+    // Round to nearest pixel and return
+    return int2(screen_coords + 0.5f);
+}
 
-    // If out of screen, do nothing
-    if (point_pixel.x < 0 || point_pixel.y < 0 || point_pixel.x >= int(W) || point_pixel.y >= int(H))
+// Function: Compute the 3D covariance matrix for a Gaussian
+float3x3 computeCov3D(float3 scale, float4 rotation)
+{
+    // Create scaling matrix
+    float3x3 S = float3x3(
+        scale.x, 0.0f, 0.0f,
+        0.0f, scale.y, 0.0f,
+        0.0f, 0.0f, scale.z
+    );
+
+    // Normalize quaternion
+    float r = rotation.x;
+    float x = rotation.y;
+    float y = rotation.z;
+    float z = rotation.w;
+
+    // Compute rotation matrix from quaternion
+    float3x3 R = float3x3(
+        1.0f - 2.0f * (y * y + z * z), 2.0f * (x * y - r * z), 2.0f * (x * z + r * y),
+        2.0f * (x * y + r * z), 1.0f - 2.0f * (x * x + z * z), 2.0f * (y * z - r * x),
+        2.0f * (x * z - r * y), 2.0f * (y * z + r * x), 1.0f - 2.0f * (x * x + y * y)
+    );
+
+    // Compute the transformation matrix
+    float3x3 M = mul(S, R);
+
+    // Compute 3D covariance matrix
+    float3x3 Sigma = mul(transpose(M), M);
+
+    // Return the covariance matrix (upper triangular matrix)
+    return float3x3(
+        Sigma[0][0], Sigma[0][1], Sigma[0][2],
+        0.0f, Sigma[1][1], Sigma[1][2],
+        0.0f, 0.0f, Sigma[2][2]
+    );
+}
+
+// Function: Compute the 2D covariance matrix for a Gaussian
+float3 computeCov2D(
+    float3 mean,
+    float focal_length, // Single focal length
+    uint2 resolution,   // Screen resolution
+    float3x3 cov3D,     // 3D covariance matrix
+    float4x4 viewmatrix // Camera view matrix
+)
+{
+    // Calculate aspect ratio
+    float aspect_ratio = (float)resolution.x / (float)resolution.y;
+
+    // Compute focal_x and focal_y from focal_length
+    float focal_x = focal_length * aspect_ratio;
+    float focal_y = focal_length;
+
+    // Transform the point to view space
+    float4 t = mul(viewmatrix, float4(mean, 1.0f));
+    float3 t_view = t.xyz / t.w;
+
+    // Compute Jacobian matrix
+    float3x3 J = float3x3(
+        focal_x / t_view.z, 0.0f, -(focal_x * t_view.x) / (t_view.z * t_view.z),
+        0.0f, focal_y / t_view.z, -(focal_y * t_view.y) / (t_view.z * t_view.z),
+        0.0f, 0.0f, 0.0f
+    );
+
+    // Compute transformation matrix
+    float3x3 W = float3x3(
+        viewmatrix[0].xyz,
+        viewmatrix[1].xyz,
+        viewmatrix[2].xyz
+    );
+
+    float3x3 T = mul(W, J);
+
+    // Compute 2D covariance matrix
+    float3x3 cov = mul(transpose(T), mul(cov3D, T));
+
+    // Apply low-pass filter
+    cov[0][0] += 0.3f;
+    cov[1][1] += 0.3f;
+
+    // Return the 2D covariance matrix (compressed form)
+    return float3(cov[0][0], cov[0][1], cov[1][1]);
+}
+
+// Main Compute Shader
+[numthreads(256, 1, 1)]
+void main(uint2 Gid : SV_GroupID, uint2 DTid : SV_DispatchThreadID, uint groupIndex : SV_GroupIndex)
+{
+    // Global thread index along X-axis
+    uint idx = DTid.x;
+
+    // Exit if out of range
+    if (idx >= gaussians.num_gaussians)
         return;
 
-    // Check both oldValue and the updated value
-    if (oldValue == 0 && newValue == 1)
+    // Load camera data
+    ShaderCamera camera = GetCamera();
+    uint W = camera.internal_resolution.x;
+    uint H = camera.internal_resolution.y;
+    float focalLength = camera.focal_length;
+
+    // Load instance and geometry
+    ShaderMeshInstance gs_instance = load_instance(gaussians.instanceIndex);
+    uint subsetIndex = gaussians.geometryIndex - gs_instance.geometryOffset;
+    ShaderGeometry geometry = load_geometry(subsetIndex);
+
+    Buffer<float4> vb_pos_w = bindless_buffers_float4[geometry.vb_pos_w];
+    float3 pos = vb_pos_w[idx].xyz;
+
+    // Step 1: Compute 3D covariance matrix
+    float3 scale = float3(1.0, 1.0, 1.0); // Replace with actual scale
+    float4 rotation = float4(1.0, 0.0, 0.0, 0.0); // Replace with actual rotation
+    float3x3 cov3D = computeCov3D(scale, rotation);
+
+    // Step 2: Compute 2D covariance matrix
+    float3 cov2D = computeCov2D(pos, focalLength, uint2(W, H), cov3D, camera.view);
+
+    // Step 3: Invert 2D covariance matrix (EWA algorithm)
+    float det = (cov2D.x * cov2D.z - cov2D.y * cov2D.y);
+    if (det == 0.0f)
+        return;
+
+    float det_inv = 1.0f / det;
+    float3 conic = float3(
+        cov2D.z * det_inv,
+        -cov2D.y * det_inv,
+        cov2D.x * det_inv
+    );
+
+    // Step 4: Compute Eigenvalues and radius
+    float mid = 0.5f * (cov2D.x + cov2D.z);
+    float lambda1 = mid + sqrt(max(0.1f, mid * mid - det));
+    float lambda2 = mid - sqrt(max(0.1f, mid * mid - det));
+    float radius = ceil(3.0f * sqrt(max(lambda1, lambda2)));
+
+    // Step 5: Compute bounding rectangle in screen space
+    uint2 rect_min, rect_max;
+    getRect(float2(pos.x, pos.y), int(radius), uint2(W / 16, H / 16), rect_min, rect_max);
+
+    if ((rect_max.x - rect_min.x) * (rect_max.y - rect_min.y) == 0)
+        return;
+
+    // Step 6: Write pixel values for debugging
+    int2 pixel_coord = worldToPixel(pos, camera, W, H);
+    if (pixel_coord.x >= 0 && pixel_coord.x < int(W) && pixel_coord.y >= 0 && pixel_coord.y < int(H))
     {
-        inout_color[point_pixel] = float4(1, 1, 1, 1); // White
+        inout_color[pixel_coord] = float4(1.0f, 1.0f, 0.0f, 1.0f); // Mark the pixel red
     }
-    else
-    {
-        inout_color[point_pixel] = float4(1, 1, 0, 1); // Yellow
-    }
+
+    // Store results or further process here...
+    touchedTiles_0[idx] = (rect_max.y - rect_min.y) * (rect_max.x - rect_min.x);
 }


### PR DESCRIPTION
- Corrected NDC to screen coordinate conversion to prevent flipped rendering.
- Replaced clamp with boundary checks for out-of-screen exclusion.
- Resolved unintended mirrored(duplicated) scene issue.