### PR TITLE
Fix issues in build-assimp-win32 bat file

### DIFF
--- a/EnginePlugins/AssetIO/build-assimp-win32.bat
+++ b/EnginePlugins/AssetIO/build-assimp-win32.bat
@@ -1,16 +1,16 @@
 @echo off
-rem ───────────────────────────────────────────────
-rem build-assimp.bat  |  VizMotive 전용 간이 빌드/설치 스크립트
-rem ───────────────────────────────────────────────
+rem -----------------------------------------------
+rem build-assimp.bat  | VizMotive simple build/install script
+rem -----------------------------------------------
 setlocal EnableDelayedExpansion
 
-:: 1) 사용자가 바꿔 쓸 수 있는 변수
+:: 1) User configurable variables
 set CONFIGS=Debug Release
 set BUILD_DIR=%~dp0External\assimp\build
 set INSTALL_DIR=%~dp0\ThirdParty\assimp
 
-:: 2) Visual Studio 컴파일러(vcvars) 환경 설정
-::    (VS 2022 기준, 다른 버전이면 경로 수정)
+:: 2) Setup Visual Studio compiler environment
+::    (For VS 2022; change if using a different version)
 call "%ProgramFiles%\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
 
 echo === [Configure] ===========================================================
@@ -27,43 +27,28 @@ cmake -S "%~dp0External\assimp" ^
       -DASSIMP_BUILD_TESTS=OFF ^
       -DASSIMP_INSTALL=ON ^
       -DASSIMP_INJECT_DEBUG_POSTFIX=ON ^
-      -DASSIMP_BUILD_DRACO=ON 
+      -DASSIMP_BUILD_DRACO=ON
 
 if errorlevel 1 goto :err
 
-rem 2) Loop over configs
+rem 3) Loop over configurations
 for %%C in (%CONFIGS%) do (
     echo === [Build %%C] ======================================================
     cmake --build "%BUILD_DIR%" --config %%C --target install
     if errorlevel 1 goto :err
 )
 
-if exist "%INSTALL_DIR%\lib\draco_md.lib" (
-del "%INSTALL_DIR%\lib\draco_md.lib"
-)
-if exist "%INSTALL_DIR%\lib\draco_mdd.lib" (
-del "%INSTALL_DIR%\lib\draco_mdd.lib"
-)
-if exist "%INSTALL_DIR%\lib\zlibstatic_md.lib" (
-del "%INSTALL_DIR%\lib\zlibstatic_md.lib"
-)
-if exist "%INSTALL_DIR%\lib\zlibstatic_mdd.lib" (
-del "%INSTALL_DIR%\lib\zlibstatic_mdd.lib"
-)
+rem 4) Delete unwanted libs
+if exist "%INSTALL_DIR%\lib\draco_md.lib" del "%INSTALL_DIR%\lib\draco_md.lib"
+if exist "%INSTALL_DIR%\lib\draco_mdd.lib" del "%INSTALL_DIR%\lib\draco_mdd.lib"
+if exist "%INSTALL_DIR%\lib\zlibstatic_md.lib" del "%INSTALL_DIR%\lib\zlibstatic_md.lib"
+if exist "%INSTALL_DIR%\lib\zlibstatic_mdd.lib" del "%INSTALL_DIR%\lib\zlibstatic_mdd.lib"
 
-@echo off
-if exist "%INSTALL_DIR%\lib\draco.lib" (
-    rename "%INSTALL_DIR%\lib\draco.lib" "draco_md.lib"
-) 
-if exist "%INSTALL_DIR%\lib\dracod.lib" (
-    rename "%INSTALL_DIR%\lib\dracod.lib" "draco_mdd.lib"
-)
-if exist "%INSTALL_DIR%\lib\zlibstatic.lib" (
-    rename "%INSTALL_DIR%\lib\zlibstatic.lib" "zlibstatic_md.lib"
-)
-if exist "%INSTALL_DIR%\lib\zlibstaticd.lib" (
-    rename "%INSTALL_DIR%\lib\zlibstaticd.lib" "zlibstatic_mdd.lib"
-)
+rem 5) Rename libs
+if exist "%INSTALL_DIR%\lib\draco.lib" rename "%INSTALL_DIR%\lib\draco.lib" "draco_md.lib"
+if exist "%INSTALL_DIR%\lib\dracod.lib" rename "%INSTALL_DIR%\lib\dracod.lib" "draco_mdd.lib"
+if exist "%INSTALL_DIR%\lib\zlibstatic.lib" rename "%INSTALL_DIR%\lib\zlibstatic.lib" "zlibstatic_md.lib"
+if exist "%INSTALL_DIR%\lib\zlibstaticd.lib" rename "%INSTALL_DIR%\lib\zlibstaticd.lib" "zlibstatic_mdd.lib"
 
 echo *** BUILD and INSTALL SUCCESS ***
 exit /b 0


### PR DESCRIPTION
Fixed encoding and syntax errors in the build-assimp-win32.bat script to allow successful build.
Korean characters and special symbols have been removed.