### PR TITLE
fix: initialize stencil access for depth-only formats

### DIFF
--- a/GraphicsBackends/GraphicsDevice_DX12.cpp
+++ b/GraphicsBackends/GraphicsDevice_DX12.cpp
@@ -6282,6 +6282,12 @@ std::mutex queue_locker;
 					DSV.StencilBeginningAccess = DSV.DepthBeginningAccess;
 					DSV.StencilEndingAccess = DSV.DepthEndingAccess;
 				}
+				else
+				{
+					// Use NO_ACCESS for formats that do not support stencil operations
+					DSV.StencilBeginningAccess.Type = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS;
+					DSV.StencilEndingAccess.Type = D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS;
+				}
 			}
 			break;
 


### PR DESCRIPTION
문제

Depth-only 포맷(DXGI_FORMAT_D16_UNORM 등) 사용 시 D3D12 검증 오류 발생:

D3D12 ERROR: The format [DXGI_FORMAT_D16_UNORM] does not support stencil,
but render pass depth stencil desc beginning/end access implies that stencil will be used.
[ ERROR EXECUTION #1377: RENDER_PASS_LOCAL_DEPTH_STENCIL_ERROR ]

원인

Depth/Stencil 포맷 종류:

| 포맷                   | Depth  | Stencil | 크기      |
|----------------------|--------|---------|---------|
| D16_UNORM            | 16-bit | ❌ 없음    | 2 bytes |
| D32_FLOAT            | 32-bit | ❌ 없음    | 4 bytes |
| D24_UNORM_S8_UINT    | 24-bit | ✅ 8-bit | 4 bytes |
| D32_FLOAT_S8X24_UINT | 32-bit | ✅ 8-bit | 8 bytes |

문제 발생 위치: GraphicsDevice_DX12.cpp:6280-6284

if (IsFormatStencilSupport(desc.format))
{
  DSV.StencilBeginningAccess = DSV.DepthBeginningAccess;
  DSV.StencilEndingAccess = DSV.DepthEndingAccess;
}
// else 블록 누락 → stencil 미지원 포맷에서 초기화되지 않은 쓰레기 값 사용

Stencil을 지원하지 않는 포맷(D16_UNORM, D32_FLOAT)에서 StencilBeginningAccess와 StencilEndingAccess가
초기화되지 않아 쓰레기 값이 들어감. D3D12가 "이 포맷은 stencil이 없는데 왜 stencil 접근 설정이 되어있냐"고
오류 발생.

해결

Stencil을 지원하지 않는 포맷에서는 NO_ACCESS로 명시적 초기화:

if (IsFormatStencilSupport(desc.format))
{
  DSV.StencilBeginningAccess = DSV.DepthBeginningAccess;
  DSV.StencilEndingAccess = DSV.DepthEndingAccess;
}
else
{
  // Stencil을 지원하지 않는 포맷은 NO_ACCESS로 명시
  DSV.StencilBeginningAccess.Type = D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS;
  DSV.StencilEndingAccess.Type = D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS;
}

NO_ACCESS는 D3D12에게 "이 채널은 사용 안함"을 명시적으로 알려 검증 오류 방지 및 타일 기반 렌더링 최적화에
도움.

수정 파일

- GraphicsBackends/GraphicsDevice_DX12.cpp (6285-6290줄)